### PR TITLE
BUG: Updated neontriods dependency to use HTTPS

### DIFF
--- a/moj-fe/package.json
+++ b/moj-fe/package.json
@@ -19,7 +19,7 @@
     "draughtsboard": "^0.1.1",
     "epub.js": "^0.2.15",
     "json3": "^3.3.2",
-    "neontroids": "git+git@github.com:swilson-mojhub/neontroids.git#hub",
+    "neontroids": "https://github.com/swilson-mojhub/neontroids.git#hub",
     "snyk": "^1.30.1"
   }
 }


### PR DESCRIPTION
Updated the package.json so Neontriods is using HTTPS to fix the DXC Azure build