### PR TITLE
Hub 344/dependencies

### DIFF
--- a/moj-be/modules/migrations/migration_videos/config/install/migrate_plus.migration.videos_node_data.yml
+++ b/moj-be/modules/migrations/migration_videos/config/install/migrate_plus.migration.videos_node_data.yml
@@ -29,8 +29,8 @@ source:
       language: Language
     7:
       author: Author
-    8:
-      parent: Parent
+    # 8:
+      # parent: Parent
 # Process.
 process:
   type:
@@ -68,8 +68,5 @@ migration_dependencies:
     - videos_image
     - videos_sub_cats
 dependencies:
-  enforced:
-    module:
-    - videos_video
-    - videos_image
-    - videos_sub_cats
+  required: {  }
+  optional: {  }

--- a/moj-be/modules/migrations/migration_videos/config/install/migrate_plus.migration.videos_sub_cats.yml
+++ b/moj-be/modules/migrations/migration_videos/config/install/migrate_plus.migration.videos_sub_cats.yml
@@ -48,6 +48,5 @@ migration_dependencies:
   required:
     - videos_cats
 dependencies:
-  enforced:
-    module:
-      - videos_cats
+  required: {  }
+  optional: {  }


### PR DESCRIPTION
Removed some enforced dependencies on the video migration plugin as they were not needed and the stopped the module from being installed.