### PR TITLE
Feature/switch ansible module

### DIFF
--- a/ansible/Ansiblefile
+++ b/ansible/Ansiblefile
@@ -1,5 +1,5 @@
 site "https://galaxy.ansible.com/api/v1"
 
 role "dev-sec.os-hardening"
-role "dev-sec.ssh-hardening"
+role "dev-sec.ssh-hardening", github: "lazzurs/ansible-ssh-hardening", ref: "feature/2fa_auth"
 role "jnv.unattended-upgrades"

--- a/ansible/group_vars/bounce
+++ b/ansible/group_vars/bounce
@@ -1,1 +1,3 @@
 ssh_use_pam: true
+ssh_google_auth: true
+ssh_challengeresponseauthentication: true

--- a/ansible/host_vars/dev.admin.hub.service.hmpps.dsd.io
+++ b/ansible/host_vars/dev.admin.hub.service.hmpps.dsd.io
@@ -1,3 +1,1 @@
 env: dev
-ssh_google_auth: true
-ssh_challengeresponseauthentication: true

--- a/ansible/host_vars/dev.admin.hub.service.hmpps.dsd.io
+++ b/ansible/host_vars/dev.admin.hub.service.hmpps.dsd.io
@@ -1,1 +1,3 @@
 env: dev
+ssh_google_auth: true
+ssh_challengeresponseauthentication: true


### PR DESCRIPTION
Switching the SSH security module we use in Ansible for the bounce boxes over to using my fork of the module to support TOTP PAM module.